### PR TITLE
Changes to the memory sanitizer / heartbleed sections with live example

### DIFF
--- a/notebooks/Fuzzer.ipynb
+++ b/notebooks/Fuzzer.ipynb
@@ -1367,7 +1367,7 @@
    "source": [
     "### Generic Checkers\n",
     "\n",
-    "Buffer overflows, as [discussed above](#Buffer-Overflows), are a particular instance of a more general problem: In languages like C, a program can access arbitrary parts of its memory – even those parts that are uninitialized and possibly not even meant to be accessed.  This is necessary if you want to write an operating system, and great if you want a maximum of performance or control, but pretty bad if you want to avoid mistakes.  Fortunately, there are tools that help catching such issues at runtime, and they are great when combined with fuzzing."
+    "Buffer overflows, as [discussed above](#Buffer-Overflows), are a particular instance of a more general problem: In languages like C and C++, a program can access arbitrary parts of its memory – even those parts that are uninitialized, already freed or simply not part of the data structure you are trying to access.  This is necessary if you want to write an operating system, and great if you want a maximum of performance or control, but pretty bad if you want to avoid mistakes.  Fortunately, there are tools that help catching such issues at runtime, and they are great when combined with fuzzing."
    ]
   },
   {
@@ -1378,19 +1378,33 @@
     }
    },
    "source": [
-    "To catch problematic memory accesses during testing, one can run C programs in special _memory-checking_ environments; at runtime, these check for each and every memory read whether it accesses valid and initialized memory.  A popular example of such a tool is the [LLVM Memory Sanitizer](https://clang.llvm.org/docs/MemorySanitizer.html).  Compiling a C program with\n",
-    "\n",
-    "```sh\n",
-    "$ clang -fsanitize=memory -o program program.c\n",
-    "```\n",
-    "\n",
-    "can then reveal errors during execution:\n",
-    "```sh\n",
-    "$ ./program\n",
-    "WARNING: MemorySanitizer: use-of-uninitialized-value\n",
-    "    #0 0x7f45944b418a in main umr.cc:6\n",
-    "    #1 0x7f45938b676c in __libc_start_main libc-start.c:226\n",
-    "```"
+    "To catch problematic memory accesses during testing, one can run C programs in special _memory-checking_ environments; at runtime, these check for each and every memory operation whether it accesses valid and initialized memory. A popular example is [LLVM Address Sanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) which detects a whole set of potentially dangerous memory safety violations. In the followin example we will compile a rather simple C program with this tool and provoke an out-of-bounds read by reading past an allocated portion of memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!echo \"#include <stdlib.h>\" > program.c\n",
+    "!echo \"#include <string.h>\" >> program.c\n",
+    "!echo \"int main(int argc, char** argv) {\" >> program.c\n",
+    "!echo \"    char* buf = malloc(100);\" >> program.c     # This allocates 100 bytes...\n",
+    "!echo \"    memset(buf, 42, 100);\" >> program.c        # ... and initializes them with 42.\n",
+    "!echo \"    int index = atoi(argv[1]);\" >> program.c   # This converts the first parameter to integer\n",
+    "                                                      # Note that this checks absolutely nothing.\n",
+    "!echo \"    char val = buf[index];\" >> program.c       # We now read memory from the buffer at the\n",
+    "                                                      # specified index, potentially out-of-bounds.\n",
+    "!echo \"    free(buf);\" >> program.c                   # Clean up the memory so we don't leak.\n",
+    "!echo \"    return val;\" >> program.c\n",
+    "!echo \"}\" >> program.c\n",
+    "!cat program.c\n",
+    "!clang -fsanitize=address -g -o program program.c\n",
+    "!echo \"Running program with parameter 99\"\n",
+    "!./program 99 ; echo $? # This outputs 42.\n",
+    "!echo \"Running program with parameter 110\"\n",
+    "!./program 110          # This will cause an out-of-bounds error in AddressSanitizer"
    ]
   },
   {
@@ -1401,7 +1415,7 @@
     }
    },
    "source": [
-    "If you want to find errors in a C program, turning on memory checking during fuzzing is a no-brainer.  It will slow down execution by a certain factor (typical values are 3–5$\\times$) and also consume more memory, but CPU cycles are dead cheap compared to the human effort it takes to find these bugs – not to speak of the potential _damage_ they cause."
+    "If you want to find errors in a C program, turning on such checks for fuzzing is fairly easy.  It will slow down execution by a certain factor depending on the tool (for AddressSanitizer it is typically 2$\\times$) and also consume more memory, but CPU cycles are dead cheap compared to the human effort it takes to find these bugs – not to speak of the potential _damage_ they cause."
    ]
   },
   {
@@ -1681,7 +1695,7 @@
     }
    },
    "source": [
-    "But how was HeartBleed discovered?  Very simple.  Researchers both at the Codenomicon company as well as with Google compiled the OpenSSL library with a memory sanitizer, and then happily flooded it with fuzzed commands.  The memory sanitizer would then notice whether uninitialized memory had been accessed – and actually, it would very quickly discover this."
+    "But how was HeartBleed discovered?  Very simple.  Researchers both at the Codenomicon company as well as with Google compiled the OpenSSL library with a memory sanitizer, and then happily flooded it with fuzzed commands.  The memory sanitizer would then notice whether an out-of-bounds memory access had occurred – and actually, it would very quickly discover this."
    ]
   },
   {


### PR DESCRIPTION
Andreas, here is a first live example for using AddressSanitizer in the Fuzzer section. I also reworded some parts in that section and the Heartbleed part, let me know your thoughts. Running the included code will give you the nice ASan error and in fact this is the same error that you get with Heartbleed. One might even want to make the whole Heartbleed example in C, as it is really trivial to make (my example is already sort of Hearbleed in a nutshell and should be really easy to understand). With that, we could also show that without ASan this won't be detected necessarily.

Sascha also suggested that instead of echo'ing source code, we can write it with Python code and multiline strings, that might be a little cleaner?

Let me know your thoughts and I'll push any adjustments to this branch before merging.