### PR TITLE
Fix issue 45 : Enigma Machine picture width attribute breaks PDF export

### DIFF
--- a/notebooks/WhenToStopFuzzing.ipynb
+++ b/notebooks/WhenToStopFuzzing.ipynb
@@ -74,7 +74,7 @@
     }
    },
    "source": [
-    "![Enigma Machine](PICS/Bletchley_Park_Naval_Enigma_IMG_3604.JPG){width=100%}"
+    "![Enigma Machine](PICS/Bletchley_Park_Naval_Enigma_IMG_3604.JPG)"
    ]
   },
   {


### PR DESCRIPTION
Hope this fix is right. If you intended the picture to look different let me know and I'll try to adjust the code accordingly.