### PR TITLE
Fixed typos in the Grammar Coverage Fuzzer and Search Based Fuzzer no…

### DIFF
--- a/notebooks/GrammarCoverageFuzzer.ipynb
+++ b/notebooks/GrammarCoverageFuzzer.ipynb
@@ -298,7 +298,7 @@
    "outputs": [],
    "source": [
     "def expansion_key(symbol, expansion):\n",
-    "    \"\"\"Convert (symbol, children) into a key.  `children` can be an expansion string or a derivation tree.\"\"\"\n",
+    "    \"\"\"Convert (symbol, expansion) into a key.  `expansion` can be an expansion string or a derivation tree.\"\"\"\n",
     "    if isinstance(expansion, tuple):\n",
     "        expansion = expansion[0]\n",
     "    if not isinstance(expansion, str):\n",
@@ -1010,7 +1010,7 @@
    "source": [
     "## Deep Foresight\n",
     "\n",
-    "Selecting expansions for individual rules is a good start; however, it is not sufficient, as the following example shows.  We apply our coverage fuzzer on the CGI grammar from the [chapter on coverage](Coverage.ipynb):"
+    "Selecting expansions for individual rules is a good start; however, it is not sufficient, as the following example shows.  We apply our coverage fuzzer on the CGI grammar from the [chapter on grammars](Grammars.ipynb):"
    ]
   },
   {
@@ -1909,7 +1909,7 @@
     }
    },
    "source": [
-    "By default, `depth` is set to $\\infty$, indicating unlimited duplication.  True unbounded duplication could lead to problems for a recursive grammar such as `EXPR_GRAMMAR`, so `duplicate_context()` is set to no longer duplicate symbols once duplicated.  Still, if we apply it to duplicate _all_ `<expr>` expansions, we obtain a grammar with no less than 296 rules:"
+    "By default, `depth` is set to $\\infty$, indicating unlimited duplication.  True unbounded duplication could lead to problems for a recursive grammar such as `EXPR_GRAMMAR`, so `duplicate_context()` is set to no longer duplicate symbols once duplicated.  Still, if we apply it to duplicate _all_ `<expr>` expansions, we obtain a grammar with no less than 292 rules:"
    ]
   },
   {

--- a/notebooks/SearchBasedFuzzer.ipynb
+++ b/notebooks/SearchBasedFuzzer.ipynb
@@ -140,6 +140,7 @@
     "- `x, y+1`\n",
     "- `x+1, y+1`\n",
     "- `x+1, y`\n",
+    "- `x+1, y-1`\n",
     "- `x, y-1`\n",
     "\n",
     "To keep things simple, let's restrict the size of our search space to start with (we will change this later). For example, let's assume we only want values in the range of -1000 to 1000:"
@@ -1039,7 +1040,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `neighbour_strings()` function gets the numerical value of each character in the input string, and creates a new string with the character replaced with the preceding and succeeding characters in the alphabet. To start with, we only consider printable ASCII characters, which are in the range 20--127."
+    "The `neighbour_strings()` function gets the numerical value of each character in the input string, and creates a new string with the character replaced with the preceding and succeeding characters in the alphabet. To start with, we only consider printable ASCII characters, which are in the range 32-126."
    ]
   },
   {
@@ -1375,7 +1376,7 @@
     "if (evaluate_condition(4, 'In', digit_high, hex_values) and evaluate_condition(5, 'In', digit_low, hex_values))\n",
     "`\n",
     "\n",
-    "Of course we would like to automatically produce this instrumented varion."
+    "Of course we would like to automatically produce this instrumented version."
    ]
   },
   {
@@ -1860,7 +1861,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "UTF-8 characters are represented with 16 bits, and this gives us a range of 65536 possible characters. The functions above are adapted to these boundaries. Before we run the hillclimber again, let's make one more change: We will add an iteration limit so that we can give up the search, rather than waiting forever for it to complete."
+    "UTF-16 characters are represented with 16 bits, and this gives us a range of 65536 possible characters. The functions above are adapted to these boundaries. Before we run the hillclimber again, let's make one more change: We will add an iteration limit so that we can give up the search, rather than waiting forever for it to complete."
    ]
   },
   {


### PR DESCRIPTION
Fixed typos in the Grammar Coverage Fuzzer and Search Based Fuzzer notebooks. These are only text changes (either in the chapter or in code comments).
I am not sure what the "varion" was supposed to mean, so I changed it to version.
CGI_GRAMMAR was defined in the grammars chapter so I updated it accordingly.