### PR TITLE
Fix bookutils::print_content()

### DIFF
--- a/notebooks/bookutils/__init__.py
+++ b/notebooks/bookutils/__init__.py
@@ -125,14 +125,12 @@ def print_content(content, filename=None, lexer=None, start_line_number=None):
         if start_line_number is None:
            print(colorful_content, end="")
            return
-        colorful_content_list = colorful_content.split("\n")
+        colorful_content_list = colorful_content.strip().split("\n")
         no_of_lines = len(colorful_content_list)
-        size_of_lines_nums = len(str(no_of_lines))
-
-        for i in range(start_line_number, start_line_number + no_of_lines):
-            colorful_content_list[i] = ('{0:' + str(size_of_lines_nums) + '}').format(i) + " " + colorful_content_list[i]
+        size_of_lines_nums = len(str(start_line_number + no_of_lines))
+        for i, line in enumerate(colorful_content_list):
+            colorful_content_list[i] = ('{0:' + str(size_of_lines_nums) + '}:').format(i + start_line_number) + " " + line
         colorful_content_with_line_no = '\n'.join(colorful_content_list)
-
         print(colorful_content_with_line_no, end="")
     else:
         print(content, end="")


### PR DESCRIPTION
print_content() method in bookutils incorrectly processes start_line_number argument