### PR TITLE
Typo: double can in Graybox Fuzzing chapter

### DIFF
--- a/docs/beta/html/GreyboxFuzzer.html
+++ b/docs/beta/html/GreyboxFuzzer.html
@@ -12298,7 +12298,7 @@ The instrumentation is usually done at compile-time, i.e., when the program sour
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html"><p>The power schedule that is implemented below assigns each seed the same energy. Once a seed is in the population, it will be fuzzed as often as any other seed in the population.</p>
-<p>In Python, we can can squeeze long for-loops into much smaller statements.</p>
+<p>In Python, we can squeeze long for-loops into much smaller statements.</p>
 <ul>
 <li><code>lambda x: ...</code> returns a function that takes <code>x</code> as input. Lambda allows for quick definitions unnamed functions.</li>
 <li><code>map(f, l)</code> returns a list where the function <code>f</code> is applied to each element in list <code>l</code>.</li>

--- a/docs/beta/notebooks/GreyboxFuzzer.ipynb
+++ b/docs/beta/notebooks/GreyboxFuzzer.ipynb
@@ -386,7 +386,7 @@
    "source": [
     "The power schedule that is implemented below assigns each seed the same energy. Once a seed is in the population, it will be fuzzed as often as any other seed in the population.\n",
     "\n",
-    "In Python, we can can squeeze long for-loops into much smaller statements.\n",
+    "In Python, we can squeeze long for-loops into much smaller statements.\n",
     "* `lambda x: ...` returns a function that takes `x` as input. Lambda allows for quick definitions unnamed functions.\n",
     "* `map(f, l)` returns a list where the function `f` is applied to each element in list `l`.\n",
     "* `np.random.choice(l,p)` returns element `l[i]` with probability in `p[i]`."

--- a/docs/beta/notebooks/Greybox_Fuzzing.ipynb
+++ b/docs/beta/notebooks/Greybox_Fuzzing.ipynb
@@ -188,7 +188,7 @@
     "### Power Schedule\n",
     "The power schedule that is implemented below assigns each seed the same energy. Once a seed is in the population, it will be fuzzed as often as any other seed in the population.\n",
     "\n",
-    "In Python, we can can squeeze long for-loops into much smaller statements.\n",
+    "In Python, we can squeeze long for-loops into much smaller statements.\n",
     "* `lambda x: ...` returns a function that takes `x` as input. Lambda allows for quick definitions unnamed functions.\n",
     "* `map(f, l)` returns a list where the function `f` is applied to each element in list `l`.\n",
     "* `np.random.choice(l,p)` returns element `l[i]` with probability in `p[i]`."

--- a/docs/beta/slides/GreyboxFuzzer.slides.html
+++ b/docs/beta/slides/GreyboxFuzzer.slides.html
@@ -14154,7 +14154,7 @@ The instrumentation is usually done at compile-time, i.e., when the program sour
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>The power schedule that is implemented below assigns each seed the same energy. Once a seed is in the population, it will be fuzzed as often as any other seed in the population.</p>
-<p>In Python, we can can squeeze long for-loops into much smaller statements.</p>
+<p>In Python, we can squeeze long for-loops into much smaller statements.</p>
 <ul>
 <li><code>lambda x: ...</code> returns a function that takes <code>x</code> as input. Lambda allows for quick definitions unnamed functions.</li>
 <li><code>map(f, l)</code> returns a list where the function <code>f</code> is applied to each element in list <code>l</code>.</li>

--- a/docs/html/GreyboxFuzzer.html
+++ b/docs/html/GreyboxFuzzer.html
@@ -12295,7 +12295,7 @@ The instrumentation is usually done at compile-time, i.e., when the program sour
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html"><p>The power schedule that is implemented below assigns each seed the same energy. Once a seed is in the population, it will be fuzzed as often as any other seed in the population.</p>
-<p>In Python, we can can squeeze long for-loops into much smaller statements.</p>
+<p>In Python, we can squeeze long for-loops into much smaller statements.</p>
 <ul>
 <li><code>lambda x: ...</code> returns a function that takes <code>x</code> as input. Lambda allows for quick definitions unnamed functions.</li>
 <li><code>map(f, l)</code> returns a list where the function <code>f</code> is applied to each element in list <code>l</code>.</li>

--- a/docs/notebooks/GreyboxFuzzer.ipynb
+++ b/docs/notebooks/GreyboxFuzzer.ipynb
@@ -386,7 +386,7 @@
    "source": [
     "The power schedule that is implemented below assigns each seed the same energy. Once a seed is in the population, it will be fuzzed as often as any other seed in the population.\n",
     "\n",
-    "In Python, we can can squeeze long for-loops into much smaller statements.\n",
+    "In Python, we can squeeze long for-loops into much smaller statements.\n",
     "* `lambda x: ...` returns a function that takes `x` as input. Lambda allows for quick definitions unnamed functions.\n",
     "* `map(f, l)` returns a list where the function `f` is applied to each element in list `l`.\n",
     "* `np.random.choice(l,p)` returns element `l[i]` with probability in `p[i]`."

--- a/docs/slides/GreyboxFuzzer.slides.html
+++ b/docs/slides/GreyboxFuzzer.slides.html
@@ -14094,7 +14094,7 @@ The instrumentation is usually done at compile-time, i.e., when the program sour
 </div><div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html">
 <p>The power schedule that is implemented below assigns each seed the same energy. Once a seed is in the population, it will be fuzzed as often as any other seed in the population.</p>
-<p>In Python, we can can squeeze long for-loops into much smaller statements.</p>
+<p>In Python, we can squeeze long for-loops into much smaller statements.</p>
 <ul>
 <li><code>lambda x: ...</code> returns a function that takes <code>x</code> as input. Lambda allows for quick definitions unnamed functions.</li>
 <li><code>map(f, l)</code> returns a list where the function <code>f</code> is applied to each element in list <code>l</code>.</li>

--- a/notebooks/GreyboxFuzzer.ipynb
+++ b/notebooks/GreyboxFuzzer.ipynb
@@ -307,7 +307,7 @@
    "source": [
     "The power schedule that is implemented below assigns each seed the same energy. Once a seed is in the population, it will be fuzzed as often as any other seed in the population.\n",
     "\n",
-    "In Python, we can can squeeze long for-loops into much smaller statements.\n",
+    "In Python, we can squeeze long for-loops into much smaller statements.\n",
     "* `lambda x: ...` returns a function that takes `x` as input. Lambda allows for quick definitions unnamed functions.\n",
     "* `map(f, l)` returns a list where the function `f` is applied to each element in list `l`.\n",
     "* `np.random.choice(l,p)` returns element `l[i]` with probability in `p[i]`."


### PR DESCRIPTION
I just have spotted double can typo in Graybox Fuzzing chapter in section [Power Schedules](https://www.fuzzingbook.org/html/GreyboxFuzzer.html#Power-Schedules). I fixed all appearances through the repository but I am not sure if this is the correct way to fix this. I can update the PR as needed, just let me know.