### PR TITLE
Performance fix for all grammar fuzzers

### DIFF
--- a/notebooks/Grammars.ipynb
+++ b/notebooks/Grammars.ipynb
@@ -719,7 +719,7 @@
     "    if isinstance(expansion, tuple):\n",
     "        expansion = expansion[0]\n",
     "\n",
-    "    return re.findall(RE_NONTERMINAL, expansion)"
+    "    return RE_NONTERMINAL.findall(expansion)"
    ]
   },
   {
@@ -777,7 +777,7 @@
    "outputs": [],
    "source": [
     "def is_nonterminal(s):\n",
-    "    return re.match(RE_NONTERMINAL, s)"
+    "    return RE_NONTERMINAL.match(s)"
    ]
   },
   {


### PR DESCRIPTION
Before, all calls to `nonterminals` and `is_nonterminal` called `re.match` / `re.findall`, which lead to repeated compilations of the `RE_NONTERMINAL` regular expression. Instead, one can call `RE_NONTERMINAL.match` / `RE_NONTERMINAL.findall`, such that the regular expression is only compiled once. This innocuous change induces a significant performance boost in my experience!