### PR TITLE
Fixed small error in JSON grammar

### DIFF
--- a/notebooks/Grammars.ipynb
+++ b/notebooks/Grammars.ipynb
@@ -3613,7 +3613,7 @@
     "\n",
     "    \"<number>\": [\"<int><frac><exp>\"],\n",
     "\n",
-    "    \"<int>\": [\"<digit>\", \"<onenine><digits>\", \"-<digits>\", \"-<onenine><digits>\"],\n",
+    "    \"<int>\": [\"<digit>\", \"<onenine><digits>\", \"-<digit>\", \"-<onenine><digits>\"],\n",
     "\n",
     "    \"<digits>\": [\"<digit>+\"],\n",
     "\n",


### PR DESCRIPTION
I found and fixed a small error in the JSON grammar, which allowed it to represent integers like "-01" that are not valid json. This was probably a typo ("-<digits>" instead of "-<digit>", as in the JSON grammar at https://www.json.org/json-en.html).