### PR TITLE
Never use `python` or `pip` directly as the PATH in the Jupyter notebooks may differ

### DIFF
--- a/notebooks/FuzzingInTheLarge.ipynb
+++ b/notebooks/FuzzingInTheLarge.ipynb
@@ -218,12 +218,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The base repository is `https://github.com/MozillaSecurity/FuzzManager` but we use the `uds-se` repository as this repository has the `0.4.1` stable release of FuzzManager."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "!git clone https://github.com/MozillaSecurity/FuzzManager"
+    "!git clone https://github.com/uds-se/FuzzManager"
    ]
   },
   {
@@ -233,8 +240,7 @@
    "outputs": [],
    "source": [
     "# ignore\n",
-    "# We use the stable release 0.4.1\n",
-    "!cd FuzzManager; git checkout 0.4.1"
+    "!{sys.executable} -m pip install -r FuzzManager/server/requirements.txt > /dev/null"
    ]
   },
   {
@@ -243,17 +249,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ignore\n",
-    "!pip install -r FuzzManager/server/requirements.txt > /dev/null"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cd FuzzManager; python server/manage.py migrate > /dev/null"
+    "!cd FuzzManager; {sys.executable} server/manage.py migrate > /dev/null"
    ]
   },
   {
@@ -269,7 +265,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!(cd FuzzManager; echo \"from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('demo', 'demo@fuzzingbook.org', 'demo')\" | python server/manage.py shell)"
+    "!(cd FuzzManager; echo \"from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('demo', 'demo@fuzzingbook.org', 'demo')\" | {sys.executable} server/manage.py shell)"
    ]
   },
   {
@@ -702,7 +698,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!git clone https://github.com/choller/simply-buggy"
+    "!git clone https://github.com/uds-se/simply-buggy"
    ]
   },
   {
@@ -1554,7 +1550,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!git clone https://github.com/choller/simply-buggy $HOME/simply-buggy-server    "
+    "!git clone https://github.com/uds-se/simply-buggy simply-buggy-server    "
    ]
   },
   {
@@ -1563,7 +1559,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cd FuzzManager; python3 server/manage.py setup_repository simply-buggy GITSourceCodeProvider $HOME/simply-buggy-server"
+    "!cd FuzzManager; {sys.executable} server/manage.py setup_repository simply-buggy GITSourceCodeProvider ../simply-buggy-server"
    ]
   },
   {
@@ -1655,7 +1651,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cd FuzzManager; python3 -mCovReporter --repository simply-buggy --description \"Test1\" --submit ../coverage.json"
+    "!cd FuzzManager; {sys.executable} -mCovReporter --repository simply-buggy --description \"Test1\" --submit ../coverage.json"
    ]
   },
   {
@@ -1891,7 +1887,7 @@
     "# ignore\n",
     "home = os.path.expanduser(\"~\")\n",
     "for temp_dir in ['coverage', 'simply-buggy', 'simply-buggy-server',\n",
-    "                 os.path.join(home, 'simply-buggy-server'),\n",
+    "                 'simply-buggy-server',\n",
     "                 'FuzzManager']:\n",
     "    if os.path.exists(temp_dir):\n",
     "        shutil.rmtree(temp_dir)"


### PR DESCRIPTION
Previously, we invoked `python` and `pip` which resulted in some python 
in the user environment and its installation being clobbered. This is because
the $PATH variable in the notebook need not be what the Jupyter notebook
commandline was started with.
This also resulted in assertion failures. This checkin uses `{sys.executable}` instead.

Further, it also ensures that we use `uds-se` versions of the external repositories.
Unfortunately, we still write to the home directory of the user by overwriting the
fuzzmanager configuration file. This needs to be removed in future. We can do
that by fixing the code in the uds-se repositories above.