### PR TITLE
Ensured that getPathID has deterministic behavior.

### DIFF
--- a/notebooks/GreyboxFuzzer.ipynb
+++ b/notebooks/GreyboxFuzzer.ipynb
@@ -993,7 +993,7 @@
    "source": [
     "def getPathID(coverage: Any) -> str:\n",
     "    \"\"\"Returns a unique hash for the covered statements\"\"\"\n",
-    "    pickled = pickle.dumps(coverage)\n",
+    "    pickled = pickle.dumps(sorted(coverage))\n",
     "    return hashlib.md5(pickled).hexdigest()"
    ]
   },


### PR DESCRIPTION
This addresses some nondeterministic behavior in `CountingGreyboxFuzzer`.