### PR TITLE
Update expansion_key to handle empty alternatives

### DIFF
--- a/docs/code/GrammarCoverageFuzzer.py
+++ b/docs/code/GrammarCoverageFuzzer.py
@@ -196,6 +196,10 @@ def expansion_key(symbol: str,
     if isinstance(expansion, tuple):
         # Expansion or single derivation tree
         expansion, _ = expansion
+        
+    # Check for empty list expansion
+    if isinstance(expansion, list) and not expansion:
+        expansion = ""
 
     if not isinstance(expansion, str):
         # Derivation tree


### PR DESCRIPTION
When using the ProbabilisticGrammarMiner to learn the probability distribution from a set of given inputs, the miner does not return the correct probabilistic grammar. In particular, this bug occurs whenever a grammar is used with a production rule that has an "empty" alternative: ⟨maybe_minus⟩ ::= "" | "-". Somehow the miner does not account for the empty ("") derivation sequence. See Issue #153 