### PR TITLE
Fix a TypeError

### DIFF
--- a/docs/code/LangFuzzer.py
+++ b/docs/code/LangFuzzer.py
@@ -427,7 +427,7 @@ class LangFuzzer2(LangFuzzer):
             if self.check_diversity(pool):
                 return random.choice(self.fragments[name])
             else:
-                return None
+                return (name, None)
         else:
             return (name,
                     [self.generate_new_tree(c, choice) for c in children])


### PR DESCRIPTION
When running LangFuzzer2 fuzzer, there is a crash:

```
Traceback (most recent call last):
...
    v = lf.fuzz()
  File "/usr/local/lib/python3.10/dist-packages/fuzzingbook/LangFuzzer.py", line 443, in fuzz
    modified = self.gfuzz.expand_tree(tree_with_a_hole)
  File "/usr/local/lib/python3.10/dist-packages/fuzzingbook/GrammarFuzzer.py", line 982, in expand_tree
    tree = self.expand_tree_with_strategy(
  File "/usr/local/lib/python3.10/dist-packages/fuzzingbook/GrammarFuzzer.py", line 973, in expand_tree_with_strategy
    or self.possible_expansions(tree) < limit)
  File "/usr/local/lib/python3.10/dist-packages/fuzzingbook/GrammarFuzzer.py", line 678, in possible_expansions
    return sum(self.possible_expansions(c) for c in children)
  File "/usr/local/lib/python3.10/dist-packages/fuzzingbook/GrammarFuzzer.py", line 678, in <genexpr>
    return sum(self.possible_expansions(c) for c in children)
  File "/usr/local/lib/python3.10/dist-packages/fuzzingbook/GrammarFuzzer.py", line 678, in possible_expansions
    return sum(self.possible_expansions(c) for c in children)
  File "/usr/local/lib/python3.10/dist-packages/fuzzingbook/GrammarFuzzer.py", line 678, in <genexpr>
    return sum(self.possible_expansions(c) for c in children)
  File "/usr/local/lib/python3.10/dist-packages/fuzzingbook/GrammarFuzzer.py", line 674, in possible_expansions
    (symbol, children) = node
TypeError: cannot unpack non-iterable NoneType object
```

The cause is the encounter of an unexpected NoneType object: `node`

```
 (symbol, children) = node
 if children is None:
     return 1
```

Importantly, `children` is checked against None, and not the node itself. Therefore, in our fix we assign None to `children`. And `node` remains always a tuple.


