### PR TITLE
fix typo:  Grammmar ==> Grammar

### DIFF
--- a/docs/beta/code/Reducer.py
+++ b/docs/beta/code/Reducer.py
@@ -350,10 +350,10 @@ if __name__ == '__main__':
     dd_reducer = DeltaDebuggingReducer(eval_mystery, log_test=True)
     dd_reducer.reduce(expr_input)
 
-### A Grammmar-Based Reduction Approach
+### A Grammar-Based Reduction Approach
 
 if __name__ == '__main__':
-    print('\n### A Grammmar-Based Reduction Approach')
+    print('\n### A Grammar-Based Reduction Approach')
 
 
 

--- a/docs/beta/html/Reducer.html
+++ b/docs/beta/html/Reducer.html
@@ -11939,7 +11939,7 @@ MathJax.Hub.Config({
 </li><li class="has-sub"><a href="#Delta-Debugging">&nbsp;&bull;&nbsp;&nbsp; Delta Debugging</a>
 </li><li class="has-sub"><a href="#Grammar-Based-Input-Reduction">&nbsp;&bull;&nbsp;&nbsp; Grammar-Based Input Reduction</a>
 <ul><li class="has-sub"><a href="#Lexical-Reduction-vs.-Syntactic-Rules">Lexical Reduction vs. Syntactic Rules</a>
-</li><li class="has-sub"><a href="#A-Grammmar-Based-Reduction-Approach">A Grammmar-Based Reduction Approach</a>
+</li><li class="has-sub"><a href="#A-Grammar-Based-Reduction-Approach">A Grammar-Based Reduction Approach</a>
 </li><li class="has-sub"><a href="#Simplifying-by-Replacing-Subtrees">Simplifying by Replacing Subtrees</a>
 </li><li class="has-sub"><a href="#Simplifying-by-Alternative-Expansions">Simplifying by Alternative Expansions</a>
 </li><li class="has-sub"><a href="#Excursion:-A-Class-for-Reducing-with-Grammars">Excursion: A Class for Reducing with Grammars</a>
@@ -13423,7 +13423,7 @@ Test #21 &#39;1 + (2 * 3&#39; 10 UNRESOLVED
 <div class="input_markdown">
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html"><h3 id="A-Grammmar-Based-Reduction-Approach">A Grammmar-Based Reduction Approach<a class="anchor-link" href="#A-Grammmar-Based-Reduction-Approach">&#182;</a></h3><p>To reduce inputs with high syntactical complexity, we use another approach: Rather than reducing the input string, we reduce the <em>tree</em> representing its structure.  The general idea is to start with a <em>derivation tree</em> coming from parsing the input, and then <em>substitute subtrees by smaller subtrees of the same type</em>.  These alternate subtrees can either come</p>
+<div class="text_cell_render border-box-sizing rendered_html"><h3 id="A-Grammar-Based-Reduction-Approach">A Grammar-Based Reduction Approach<a class="anchor-link" href="#A-Grammar-Based-Reduction-Approach">&#182;</a></h3><p>To reduce inputs with high syntactical complexity, we use another approach: Rather than reducing the input string, we reduce the <em>tree</em> representing its structure.  The general idea is to start with a <em>derivation tree</em> coming from parsing the input, and then <em>substitute subtrees by smaller subtrees of the same type</em>.  These alternate subtrees can either come</p>
 <ol>
 <li>From the tree itself, or</li>
 <li>By applying an alternate grammar expansion using elements from the tree.</li>

--- a/docs/beta/notebooks/Reducer.ipynb
+++ b/docs/beta/notebooks/Reducer.ipynb
@@ -1628,7 +1628,7 @@
     }
    },
    "source": [
-    "### A Grammmar-Based Reduction Approach\n",
+    "### A Grammar-Based Reduction Approach\n",
     "\n",
     "To reduce inputs with high syntactical complexity, we use another approach: Rather than reducing the input string, we reduce the _tree_ representing its structure.  The general idea is to start with a _derivation tree_ coming from parsing the input, and then _substitute subtrees by smaller subtrees of the same type_.  These alternate subtrees can either come\n",
     "\n",

--- a/docs/beta/slides/Reducer.slides.html
+++ b/docs/beta/slides/Reducer.slides.html
@@ -16794,7 +16794,7 @@ Test #21 &#39;1 + (2 * 3&#39; 10 UNRESOLVED
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
-<h3 id="A-Grammmar-Based-Reduction-Approach">A Grammmar-Based Reduction Approach<a class="anchor-link" href="#A-Grammmar-Based-Reduction-Approach">&#182;</a></h3><p>To reduce inputs with high syntactical complexity, we use another approach: Rather than reducing the input string, we reduce the <em>tree</em> representing its structure.  The general idea is to start with a <em>derivation tree</em> coming from parsing the input, and then <em>substitute subtrees by smaller subtrees of the same type</em>.  These alternate subtrees can either come</p>
+<h3 id="A-Grammar-Based-Reduction-Approach">A Grammar-Based Reduction Approach<a class="anchor-link" href="#A-Grammar-Based-Reduction-Approach">&#182;</a></h3><p>To reduce inputs with high syntactical complexity, we use another approach: Rather than reducing the input string, we reduce the <em>tree</em> representing its structure.  The general idea is to start with a <em>derivation tree</em> coming from parsing the input, and then <em>substitute subtrees by smaller subtrees of the same type</em>.  These alternate subtrees can either come</p>
 <ol>
 <li>From the tree itself, or</li>
 <li>By applying an alternate grammar expansion using elements from the tree.</li>

--- a/docs/code/Reducer.py
+++ b/docs/code/Reducer.py
@@ -350,10 +350,10 @@ if __name__ == '__main__':
     dd_reducer = DeltaDebuggingReducer(eval_mystery, log_test=True)
     dd_reducer.reduce(expr_input)
 
-### A Grammmar-Based Reduction Approach
+### A Grammar-Based Reduction Approach
 
 if __name__ == '__main__':
-    print('\n### A Grammmar-Based Reduction Approach')
+    print('\n### A Grammar-Based Reduction Approach')
 
 
 

--- a/docs/html/Reducer.html
+++ b/docs/html/Reducer.html
@@ -11939,7 +11939,7 @@ MathJax.Hub.Config({
 </li><li class="has-sub"><a href="#Delta-Debugging">&nbsp;&bull;&nbsp;&nbsp; Delta Debugging</a>
 </li><li class="has-sub"><a href="#Grammar-Based-Input-Reduction">&nbsp;&bull;&nbsp;&nbsp; Grammar-Based Input Reduction</a>
 <ul><li class="has-sub"><a href="#Lexical-Reduction-vs.-Syntactic-Rules">Lexical Reduction vs. Syntactic Rules</a>
-</li><li class="has-sub"><a href="#A-Grammmar-Based-Reduction-Approach">A Grammmar-Based Reduction Approach</a>
+</li><li class="has-sub"><a href="#A-Grammar-Based-Reduction-Approach">A Grammar-Based Reduction Approach</a>
 </li><li class="has-sub"><a href="#Simplifying-by-Replacing-Subtrees">Simplifying by Replacing Subtrees</a>
 </li><li class="has-sub"><a href="#Simplifying-by-Alternative-Expansions">Simplifying by Alternative Expansions</a>
 </li><li class="has-sub"><a href="#Excursion:-A-Class-for-Reducing-with-Grammars">Excursion: A Class for Reducing with Grammars</a>
@@ -13423,7 +13423,7 @@ Test #21 &#39;1 + (2 * 3&#39; 10 UNRESOLVED
 <div class="input_markdown">
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html"><h3 id="A-Grammmar-Based-Reduction-Approach">A Grammmar-Based Reduction Approach<a class="anchor-link" href="#A-Grammmar-Based-Reduction-Approach">&#182;</a></h3><p>To reduce inputs with high syntactical complexity, we use another approach: Rather than reducing the input string, we reduce the <em>tree</em> representing its structure.  The general idea is to start with a <em>derivation tree</em> coming from parsing the input, and then <em>substitute subtrees by smaller subtrees of the same type</em>.  These alternate subtrees can either come</p>
+<div class="text_cell_render border-box-sizing rendered_html"><h3 id="A-Grammar-Based-Reduction-Approach">A Grammar-Based Reduction Approach<a class="anchor-link" href="#A-Grammar-Based-Reduction-Approach">&#182;</a></h3><p>To reduce inputs with high syntactical complexity, we use another approach: Rather than reducing the input string, we reduce the <em>tree</em> representing its structure.  The general idea is to start with a <em>derivation tree</em> coming from parsing the input, and then <em>substitute subtrees by smaller subtrees of the same type</em>.  These alternate subtrees can either come</p>
 <ol>
 <li>From the tree itself, or</li>
 <li>By applying an alternate grammar expansion using elements from the tree.</li>

--- a/docs/notebooks/Reducer.ipynb
+++ b/docs/notebooks/Reducer.ipynb
@@ -1628,7 +1628,7 @@
     }
    },
    "source": [
-    "### A Grammmar-Based Reduction Approach\n",
+    "### A Grammar-Based Reduction Approach\n",
     "\n",
     "To reduce inputs with high syntactical complexity, we use another approach: Rather than reducing the input string, we reduce the _tree_ representing its structure.  The general idea is to start with a _derivation tree_ coming from parsing the input, and then _substitute subtrees by smaller subtrees of the same type_.  These alternate subtrees can either come\n",
     "\n",

--- a/docs/slides/Reducer.slides.html
+++ b/docs/slides/Reducer.slides.html
@@ -16794,7 +16794,7 @@ Test #21 &#39;1 + (2 * 3&#39; 10 UNRESOLVED
 </div>
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
-<h3 id="A-Grammmar-Based-Reduction-Approach">A Grammmar-Based Reduction Approach<a class="anchor-link" href="#A-Grammmar-Based-Reduction-Approach">&#182;</a></h3><p>To reduce inputs with high syntactical complexity, we use another approach: Rather than reducing the input string, we reduce the <em>tree</em> representing its structure.  The general idea is to start with a <em>derivation tree</em> coming from parsing the input, and then <em>substitute subtrees by smaller subtrees of the same type</em>.  These alternate subtrees can either come</p>
+<h3 id="A-Grammar-Based-Reduction-Approach">A Grammar-Based Reduction Approach<a class="anchor-link" href="#A-Grammar-Based-Reduction-Approach">&#182;</a></h3><p>To reduce inputs with high syntactical complexity, we use another approach: Rather than reducing the input string, we reduce the <em>tree</em> representing its structure.  The general idea is to start with a <em>derivation tree</em> coming from parsing the input, and then <em>substitute subtrees by smaller subtrees of the same type</em>.  These alternate subtrees can either come</p>
 <ol>
 <li>From the tree itself, or</li>
 <li>By applying an alternate grammar expansion using elements from the tree.</li>


### PR DESCRIPTION
There exist some words 'Grammar' in files (e.g., *.py, *.html), and I suspect they are typos, so I will fix them to 'Grammar.'