### PR TITLE
 GeneratorGrammarFuzzer: Fix order of expansions with explicit ordering (#171)

### DIFF
--- a/docs/beta/code/GeneratorGrammarFuzzer.py
+++ b/docs/beta/code/GeneratorGrammarFuzzer.py
@@ -875,7 +875,7 @@ class GeneratorGrammarFuzzer(GeneratorGrammarFuzzer):
                 print("Expandable child #%d %s has order %d" %
                       (k, expandable_child[0], given_order[j]))
 
-            if min_given_order is None or given_order[j] < min_given_order:
+            if min_given_order is None or given_order[j] < given_order[min_given_order]:
                 min_given_order = k
 
         assert min_given_order is not None

--- a/docs/beta/notebooks/GeneratorGrammarFuzzer.ipynb
+++ b/docs/beta/notebooks/GeneratorGrammarFuzzer.ipynb
@@ -3506,7 +3506,7 @@
     "                print(\"Expandable child #%d %s has order %d\" %\n",
     "                      (k, expandable_child[0], given_order[j]))\n",
     "\n",
-    "            if min_given_order is None or given_order[j] < min_given_order:\n",
+    "            if min_given_order is None or given_order[j] < given_order[min_given_order]:\n",
     "                min_given_order = k\n",
     "\n",
     "        assert min_given_order is not None\n",

--- a/docs/code/GeneratorGrammarFuzzer.py
+++ b/docs/code/GeneratorGrammarFuzzer.py
@@ -875,7 +875,7 @@ class GeneratorGrammarFuzzer(GeneratorGrammarFuzzer):
                 print("Expandable child #%d %s has order %d" %
                       (k, expandable_child[0], given_order[j]))
 
-            if min_given_order is None or given_order[j] < min_given_order:
+            if min_given_order is None or given_order[j] < given_order[min_given_order]:
                 min_given_order = k
 
         assert min_given_order is not None

--- a/docs/notebooks/GeneratorGrammarFuzzer.ipynb
+++ b/docs/notebooks/GeneratorGrammarFuzzer.ipynb
@@ -3506,7 +3506,7 @@
     "                print(\"Expandable child #%d %s has order %d\" %\n",
     "                      (k, expandable_child[0], given_order[j]))\n",
     "\n",
-    "            if min_given_order is None or given_order[j] < min_given_order:\n",
+    "            if min_given_order is None or given_order[j] < given_order[min_given_order]:\n",
     "                min_given_order = k\n",
     "\n",
     "        assert min_given_order is not None\n",

--- a/notebooks/GeneratorGrammarFuzzer.ipynb
+++ b/notebooks/GeneratorGrammarFuzzer.ipynb
@@ -1977,7 +1977,7 @@
     "                print(\"Expandable child #%d %s has order %d\" %\n",
     "                      (k, expandable_child[0], given_order[j]))\n",
     "\n",
-    "            if min_given_order is None or given_order[j] < min_given_order:\n",
+    "            if min_given_order is None or given_order[j] < given_order[min_given_order]:\n",
     "                min_given_order = k\n",
     "\n",
     "        assert min_given_order is not None\n",


### PR DESCRIPTION
There is an issue in the implementation of the `order` option, that is supported by the `GeneratorGrammarFuzzer`. Instead of comparing the order value of an expansion, it compares the index of the order value.

Closes #171 