### PR TITLE
Fix mastodon links

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ This work is designed as a _textbook_ for a course in software testing or securi
 
 ## News
 
-This book is _work in progress._  All chapters planned are out now, but we keep on refining text and code with [minor and major releases.](https://www.fuzzingbook.org/html/ReleaseNotes.html)  To get notified on updates, <a href="https://mastodon.social/invite/3CvrkW9t">follow us on Mastodon</a>.
+This book is _work in progress._  All chapters planned are out now, but we keep on refining text and code with [minor and major releases.](https://www.fuzzingbook.org/html/ReleaseNotes.html)  To get notified on updates, <a href="https://mastodon.social/@TheFuzzingBook">follow us on Mastodon</a>.
 
 <!--

--- a/docs/404.html
+++ b/docs/404.html
@@ -12069,7 +12069,7 @@ onclick="window.open('https://www.facebook.com/sharer/sharer.php?u=https%3a%2f%2
 <div class="input_markdown">
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html"><h2 id="Getting-Informed-About-New-Content">Getting Informed About New Content<a class="anchor-link" href="#Getting-Informed-About-New-Content">&#182;</a></h2><p>New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href="https://mastodon.social/invite/3CvrkW9t">follow us on Mastodon</a>.</p>
+<div class="text_cell_render border-box-sizing rendered_html"><h2 id="Getting-Informed-About-New-Content">Getting Informed About New Content<a class="anchor-link" href="#Getting-Informed-About-New-Content">&#182;</a></h2><p>New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href="https://mastodon.social/@TheFuzzingBook">follow us on Mastodon</a>.</p>
 <!--
 <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="400" height="400" frameBorder="0" src="https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false"></iframe>
 --></div>

--- a/docs/beta/404.html
+++ b/docs/beta/404.html
@@ -12069,7 +12069,7 @@ onclick="window.open('https://www.facebook.com/sharer/sharer.php?u=https%3a%2f%2
 <div class="input_markdown">
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html"><h2 id="Getting-Informed-About-New-Content">Getting Informed About New Content<a class="anchor-link" href="#Getting-Informed-About-New-Content">&#182;</a></h2><p>New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href="https://mastodon.social/invite/3CvrkW9t">follow us on Mastodon</a>.</p>
+<div class="text_cell_render border-box-sizing rendered_html"><h2 id="Getting-Informed-About-New-Content">Getting Informed About New Content<a class="anchor-link" href="#Getting-Informed-About-New-Content">&#182;</a></h2><p>New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href="https://mastodon.social/@TheFuzzingBook">follow us on Mastodon</a>.</p>
 <!--
 <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="400" height="400" frameBorder="0" src="https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false"></iframe>
 --></div>

--- a/docs/beta/html/404.html
+++ b/docs/beta/html/404.html
@@ -12071,7 +12071,7 @@ onclick="window.open('https://www.facebook.com/sharer/sharer.php?u=https%3a%2f%2
 <div class="input_markdown">
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html"><h2 id="Getting-Informed-About-New-Content">Getting Informed About New Content<a class="anchor-link" href="#Getting-Informed-About-New-Content">&#182;</a></h2><p>New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href="https://mastodon.social/invite/3CvrkW9t">follow us on Mastodon</a>.</p>
+<div class="text_cell_render border-box-sizing rendered_html"><h2 id="Getting-Informed-About-New-Content">Getting Informed About New Content<a class="anchor-link" href="#Getting-Informed-About-New-Content">&#182;</a></h2><p>New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href="https://mastodon.social/@TheFuzzingBook">follow us on Mastodon</a>.</p>
 <!--
 <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="400" height="400" frameBorder="0" src="https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false"></iframe>
 --></div>

--- a/docs/beta/html/ReleaseNotes.html
+++ b/docs/beta/html/ReleaseNotes.html
@@ -12040,7 +12040,7 @@ Major changes will show up here as we make them.</p>
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html"><h2 id="Version-1.2-(released-2023-10-23)">Version 1.2 (released 2023-10-23)<a class="anchor-link" href="#Version-1.2-(released-2023-10-23)">&#182;</a></h2><ul>
-<li>For announcements, we now use Mastodon (<a href="https://mastodon.social/@TheFuzzingBook">@TheFuzzingBook@mastodon.social</a>) instead of X. <a href="https://mastodon.social/invite/3CvrkW9t">Follow us on Mastodon</a>!</li>
+<li>For announcements, we now use Mastodon (<a href="https://mastodon.social/@TheFuzzingBook">@TheFuzzingBook@mastodon.social</a>) instead of X. <a href="https://mastodon.social/@TheFuzzingBook">Follow us on Mastodon</a>!</li>
 <li>We have a <a href="FuzzingWithConstraints.html">new chapter on Fuzzing with Constraints</a> in which we introduce the ISLa constraint language / fuzzer / parser.</li>
 <li>We have a <a href="PythonFuzzer.html">new chapter on Compiler Testing</a> in which we use grammars to generate, parse, and evolve Python code.</li>
 <li><p>We now regularly test our code on various Python versions.</p>

--- a/docs/beta/html/index.html
+++ b/docs/beta/html/index.html
@@ -12063,7 +12063,7 @@ Software has bugs, and catching bugs can involve lots of effort.  This book addr
 <div class="input_markdown">
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html"><h2 id="News">News<a class="anchor-link" href="#News">&#182;</a></h2><p>This book is <em>work in progress.</em>  All chapters planned are out now, but we keep on refining the material with <a href="ReleaseNotes.html">minor and major releases.</a>  To get notified on updates, <a href="https://mastodon.social/invite/3CvrkW9t">follow us on Mastodon</a>.</p>
+<div class="text_cell_render border-box-sizing rendered_html"><h2 id="News">News<a class="anchor-link" href="#News">&#182;</a></h2><p>This book is <em>work in progress.</em>  All chapters planned are out now, but we keep on refining the material with <a href="ReleaseNotes.html">minor and major releases.</a>  To get notified on updates, <a href="https://mastodon.social/@TheFuzzingBook">follow us on Mastodon</a>.</p>
 <!--
 <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="400" height="400" frameBorder="0" src="https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false"></iframe>
 --></div>

--- a/docs/beta/index.html
+++ b/docs/beta/index.html
@@ -12058,7 +12058,7 @@ Software has bugs, and catching bugs can involve lots of effort.  This book addr
 <div class="input_markdown">
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html"><h2 id="News">News<a class="anchor-link" href="#News">&#182;</a></h2><p>This book is <em>work in progress.</em>  All chapters planned are out now, but we keep on refining the material with <a href="html/ReleaseNotes.html">minor and major releases.</a>  To get notified on updates, <a href="https://mastodon.social/invite/3CvrkW9t">follow us on Mastodon</a>.</p>
+<div class="text_cell_render border-box-sizing rendered_html"><h2 id="News">News<a class="anchor-link" href="#News">&#182;</a></h2><p>This book is <em>work in progress.</em>  All chapters planned are out now, but we keep on refining the material with <a href="html/ReleaseNotes.html">minor and major releases.</a>  To get notified on updates, <a href="https://mastodon.social/@TheFuzzingBook">follow us on Mastodon</a>.</p>
 <!--
 <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="400" height="400" frameBorder="0" src="https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false"></iframe>
 --></div>

--- a/docs/beta/notebooks/404.ipynb
+++ b/docs/beta/notebooks/404.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "## Getting Informed About New Content\n",
     "\n",
-    "New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href=\"https://mastodon.social/invite/3CvrkW9t\">follow us on Mastodon</a>.\n",
+    "New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href=\"https://mastodon.social/@TheFuzzingBook\">follow us on Mastodon</a>.\n",
     "\n",
     "<!--\n",
     "<iframe allowfullscreen sandbox=\"allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox\" width=\"400\" height=\"400\" frameBorder=\"0\" src=\"https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false\"></iframe>\n",

--- a/docs/beta/notebooks/README.md
+++ b/docs/beta/notebooks/README.md
@@ -60,6 +60,6 @@ This work is designed as a _textbook_ for a course in software testing; as _supp
 
 ## News
 
-This book is _work in progress._  All chapters planned are out now, but we keep on refining the material with [minor and major releases.](https://www.fuzzingbook.org/html/ReleaseNotes.html)  To get notified on updates, <a href="https://mastodon.social/invite/3CvrkW9t">follow us on Mastodon</a>.
+This book is _work in progress._  All chapters planned are out now, but we keep on refining the material with [minor and major releases.](https://www.fuzzingbook.org/html/ReleaseNotes.html)  To get notified on updates, <a href="https://mastodon.social/@TheFuzzingBook">follow us on Mastodon</a>.
 
 <!--

--- a/docs/beta/notebooks/ReleaseNotes.ipynb
+++ b/docs/beta/notebooks/ReleaseNotes.ipynb
@@ -66,7 +66,7 @@
    "source": [
     "## Version 1.2 (released 2023-10-23)\n",
     "\n",
-    "* For announcements, we now use Mastodon ([@TheFuzzingBook@mastodon.social](https://mastodon.social/@TheFuzzingBook)) instead of X. <a href=\"https://mastodon.social/invite/3CvrkW9t\">Follow us on Mastodon</a>!\n",
+    "* For announcements, we now use Mastodon ([@TheFuzzingBook@mastodon.social](https://mastodon.social/@TheFuzzingBook)) instead of X. <a href=\"https://mastodon.social/@TheFuzzingBook\">Follow us on Mastodon</a>!\n",
     "* We have a [new chapter on Fuzzing with Constraints](FuzzingWithConstraints.ipynb) in which we introduce the ISLa constraint language / fuzzer / parser.\n",
     "* We have a [new chapter on Compiler Testing](PythonFuzzer.ipynb) in which we use grammars to generate, parse, and evolve Python code.\n",
     "* We now regularly test our code on various Python versions.\n",

--- a/docs/beta/notebooks/index.ipynb
+++ b/docs/beta/notebooks/index.ipynb
@@ -101,7 +101,7 @@
    "source": [
     "## News\n",
     "\n",
-    "This book is _work in progress._  All chapters planned are out now, but we keep on refining the material with [minor and major releases.](ReleaseNotes.ipynb)  To get notified on updates, <a href=\"https://mastodon.social/invite/3CvrkW9t\">follow us on Mastodon</a>.\n",
+    "This book is _work in progress._  All chapters planned are out now, but we keep on refining the material with [minor and major releases.](ReleaseNotes.ipynb)  To get notified on updates, <a href=\"https://mastodon.social/@TheFuzzingBook\">follow us on Mastodon</a>.\n",
     "\n",
     "<!--\n",
     "<iframe allowfullscreen sandbox=\"allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox\" width=\"400\" height=\"400\" frameBorder=\"0\" src=\"https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false\"></iframe>\n",

--- a/docs/html/404.html
+++ b/docs/html/404.html
@@ -12071,7 +12071,7 @@ onclick="window.open('https://www.facebook.com/sharer/sharer.php?u=https%3a%2f%2
 <div class="input_markdown">
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html"><h2 id="Getting-Informed-About-New-Content">Getting Informed About New Content<a class="anchor-link" href="#Getting-Informed-About-New-Content">&#182;</a></h2><p>New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href="https://mastodon.social/invite/3CvrkW9t">follow us on Mastodon</a>.</p>
+<div class="text_cell_render border-box-sizing rendered_html"><h2 id="Getting-Informed-About-New-Content">Getting Informed About New Content<a class="anchor-link" href="#Getting-Informed-About-New-Content">&#182;</a></h2><p>New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href="https://mastodon.social/@TheFuzzingBook">follow us on Mastodon</a>.</p>
 <!--
 <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="400" height="400" frameBorder="0" src="https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false"></iframe>
 --></div>

--- a/docs/html/ReleaseNotes.html
+++ b/docs/html/ReleaseNotes.html
@@ -12040,7 +12040,7 @@ Major changes will show up here as we make them.</p>
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
 <div class="text_cell_render border-box-sizing rendered_html"><h2 id="Version-1.2-(released-2023-10-23)">Version 1.2 (released 2023-10-23)<a class="anchor-link" href="#Version-1.2-(released-2023-10-23)">&#182;</a></h2><ul>
-<li>For announcements, we now use Mastodon (<a href="https://mastodon.social/@TheFuzzingBook">@TheFuzzingBook@mastodon.social</a>) instead of X. <a href="https://mastodon.social/invite/3CvrkW9t">Follow us on Mastodon</a>!</li>
+<li>For announcements, we now use Mastodon (<a href="https://mastodon.social/@TheFuzzingBook">@TheFuzzingBook@mastodon.social</a>) instead of X. <a href="https://mastodon.social/@TheFuzzingBook">Follow us on Mastodon</a>!</li>
 <li>We have a <a href="FuzzingWithConstraints.html">new chapter on Fuzzing with Constraints</a> in which we introduce the ISLa constraint language / fuzzer / parser.</li>
 <li>We have a <a href="PythonFuzzer.html">new chapter on Compiler Testing</a> in which we use grammars to generate, parse, and evolve Python code.</li>
 <li><p>We now regularly test our code on various Python versions.</p>

--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -12063,7 +12063,7 @@ Software has bugs, and catching bugs can involve lots of effort.  This book addr
 <div class="input_markdown">
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html"><h2 id="News">News<a class="anchor-link" href="#News">&#182;</a></h2><p>This book is <em>work in progress.</em>  All chapters planned are out now, but we keep on refining text and code with <a href="ReleaseNotes.html">minor and major releases.</a>  To get notified on updates, <a href="https://mastodon.social/invite/3CvrkW9t">follow us on Mastodon</a>.</p>
+<div class="text_cell_render border-box-sizing rendered_html"><h2 id="News">News<a class="anchor-link" href="#News">&#182;</a></h2><p>This book is <em>work in progress.</em>  All chapters planned are out now, but we keep on refining text and code with <a href="ReleaseNotes.html">minor and major releases.</a>  To get notified on updates, <a href="https://mastodon.social/@TheFuzzingBook">follow us on Mastodon</a>.</p>
 <!--
 <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="400" height="400" frameBorder="0" src="https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false"></iframe>
 --></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12058,7 +12058,7 @@ Software has bugs, and catching bugs can involve lots of effort.  This book addr
 <div class="input_markdown">
 <div class="cell border-box-sizing text_cell rendered">
 <div class="inner_cell">
-<div class="text_cell_render border-box-sizing rendered_html"><h2 id="News">News<a class="anchor-link" href="#News">&#182;</a></h2><p>This book is <em>work in progress.</em>  All chapters planned are out now, but we keep on refining text and code with <a href="html/ReleaseNotes.html">minor and major releases.</a>  To get notified on updates, <a href="https://mastodon.social/invite/3CvrkW9t">follow us on Mastodon</a>.</p>
+<div class="text_cell_render border-box-sizing rendered_html"><h2 id="News">News<a class="anchor-link" href="#News">&#182;</a></h2><p>This book is <em>work in progress.</em>  All chapters planned are out now, but we keep on refining text and code with <a href="html/ReleaseNotes.html">minor and major releases.</a>  To get notified on updates, <a href="https://mastodon.social/@TheFuzzingBook">follow us on Mastodon</a>.</p>
 <!--
 <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="400" height="400" frameBorder="0" src="https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false"></iframe>
 --></div>

--- a/docs/notebooks/404.ipynb
+++ b/docs/notebooks/404.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "## Getting Informed About New Content\n",
     "\n",
-    "New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href=\"https://mastodon.social/invite/3CvrkW9t\">follow us on Mastodon</a>.\n",
+    "New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href=\"https://mastodon.social/@TheFuzzingBook\">follow us on Mastodon</a>.\n",
     "\n",
     "<!--\n",
     "<iframe allowfullscreen sandbox=\"allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox\" width=\"400\" height=\"400\" frameBorder=\"0\" src=\"https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false\"></iframe>\n",

--- a/docs/notebooks/README.md
+++ b/docs/notebooks/README.md
@@ -60,6 +60,6 @@ This work is designed as a _textbook_ for a course in software testing or securi
 
 ## News
 
-This book is _work in progress._  All chapters planned are out now, but we keep on refining text and code with [minor and major releases.](https://www.fuzzingbook.org/html/ReleaseNotes.html)  To get notified on updates, <a href="https://mastodon.social/invite/3CvrkW9t">follow us on Mastodon</a>.
+This book is _work in progress._  All chapters planned are out now, but we keep on refining text and code with [minor and major releases.](https://www.fuzzingbook.org/html/ReleaseNotes.html)  To get notified on updates, <a href="https://mastodon.social/@TheFuzzingBook">follow us on Mastodon</a>.
 
 <!--

--- a/docs/notebooks/ReleaseNotes.ipynb
+++ b/docs/notebooks/ReleaseNotes.ipynb
@@ -66,7 +66,7 @@
    "source": [
     "## Version 1.2 (released 2023-10-23)\n",
     "\n",
-    "* For announcements, we now use Mastodon ([@TheFuzzingBook@mastodon.social](https://mastodon.social/@TheFuzzingBook)) instead of X. <a href=\"https://mastodon.social/invite/3CvrkW9t\">Follow us on Mastodon</a>!\n",
+    "* For announcements, we now use Mastodon ([@TheFuzzingBook@mastodon.social](https://mastodon.social/@TheFuzzingBook)) instead of X. <a href=\"https://mastodon.social/@TheFuzzingBook\">Follow us on Mastodon</a>!\n",
     "* We have a [new chapter on Fuzzing with Constraints](FuzzingWithConstraints.ipynb) in which we introduce the ISLa constraint language / fuzzer / parser.\n",
     "* We have a [new chapter on Compiler Testing](PythonFuzzer.ipynb) in which we use grammars to generate, parse, and evolve Python code.\n",
     "* We now regularly test our code on various Python versions.\n",

--- a/docs/notebooks/index.ipynb
+++ b/docs/notebooks/index.ipynb
@@ -101,7 +101,7 @@
    "source": [
     "## News\n",
     "\n",
-    "This book is _work in progress._  All chapters planned are out now, but we keep on refining text and code with [minor and major releases.](ReleaseNotes.ipynb)  To get notified on updates, <a href=\"https://mastodon.social/invite/3CvrkW9t\">follow us on Mastodon</a>.\n",
+    "This book is _work in progress._  All chapters planned are out now, but we keep on refining text and code with [minor and major releases.](ReleaseNotes.ipynb)  To get notified on updates, <a href=\"https://mastodon.social/@TheFuzzingBook\">follow us on Mastodon</a>.\n",
     "\n",
     "<!--\n",
     "<iframe allowfullscreen sandbox=\"allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox\" width=\"400\" height=\"400\" frameBorder=\"0\" src=\"https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false\"></iframe>\n",

--- a/notebooks/404.ipynb
+++ b/notebooks/404.ipynb
@@ -59,7 +59,7 @@
    "source": [
     "## Getting Informed About New Content\n",
     "\n",
-    "New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href=\"https://mastodon.social/invite/3CvrkW9t\">follow us on Mastodon</a>.\n",
+    "New chapters are coming out every week.  To get notified when a new chapter (or this one) comes out, <a href=\"https://mastodon.social/@TheFuzzingBook\">follow us on Mastodon</a>.\n",
     "\n",
     "<!--\n",
     "<iframe allowfullscreen sandbox=\"allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox\" width=\"400\" height=\"400\" frameBorder=\"0\" src=\"https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false\"></iframe>\n",

--- a/notebooks/ReleaseNotes.ipynb
+++ b/notebooks/ReleaseNotes.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "## Version 1.2 (released 2023-10-23)\n",
     "\n",
-    "* For announcements, we now use Mastodon ([@TheFuzzingBook@mastodon.social](https://mastodon.social/@TheFuzzingBook)) instead of X. <a href=\"https://mastodon.social/invite/3CvrkW9t\">Follow us on Mastodon</a>!\n",
+    "* For announcements, we now use Mastodon ([@TheFuzzingBook@mastodon.social](https://mastodon.social/@TheFuzzingBook)) instead of X. <a href=\"https://mastodon.social/@TheFuzzingBook\">Follow us on Mastodon</a>!\n",
     "* We have a [new chapter on Fuzzing with Constraints](FuzzingWithConstraints.ipynb) in which we introduce the ISLa constraint language / fuzzer / parser.\n",
     "* We have a [new chapter on Compiler Testing](PythonFuzzer.ipynb) in which we use grammars to generate, parse, and evolve Python code.\n",
     "* We now regularly test our code on various Python versions.\n",

--- a/notebooks/index.ipynb
+++ b/notebooks/index.ipynb
@@ -52,7 +52,7 @@
    "source": [
     "## News\n",
     "\n",
-    "This book is _work in progress._  All chapters planned are out now, but we keep on refining text and code with [minor and major releases.](ReleaseNotes.ipynb)  To get notified on updates, <a href=\"https://mastodon.social/invite/3CvrkW9t\">follow us on Mastodon</a>.\n",
+    "This book is _work in progress._  All chapters planned are out now, but we keep on refining text and code with [minor and major releases.](ReleaseNotes.ipynb)  To get notified on updates, <a href=\"https://mastodon.social/@TheFuzzingBook\">follow us on Mastodon</a>.\n",
     "\n",
     "<!--\n",
     "<iframe allowfullscreen sandbox=\"allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox\" width=\"400\" height=\"400\" frameBorder=\"0\" src=\"https://mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Fmastodon.social%2Fusers%2FTheFuzzingBook&theme=auto&size=80&header=false&replies=false&boosts=false\"></iframe>\n",


### PR DESCRIPTION
The purpose of invite links is to allow people to create accounts on invite-only instances. They are useless for instances like mastodon.social with open registration, and don't actually properly link to the account that should be followed.