### PR TITLE
Add missed description of Testing compilers

### DIFF
--- a/notebooks/05_Domain-Specific_Fuzzing.ipynb
+++ b/notebooks/05_Domain-Specific_Fuzzing.ipynb
@@ -22,6 +22,8 @@
     "\n",
     "* [Carving](Carver.ipynb) takes a system test and automatically extracts a set of _unit tests_ that replicate the calls seen during the unit test.  The key idea is to _record_ such calls such that we can _replay_ them later – as a whole or selectively.\n",
     "\n",
+    "* [Testing Compilers](PythonFuzzer.ipynb) shows how to systematically explore the behavior of a compiler or an interpreter using _grammars_ and _grammar-based testing_ to systematically generate program code.\n",
+    "\n",
     "* [Testing Web Applications](WebFuzzer.ipynb) shows how to systematically explore the behavior of a Web application – first with handwritten grammars, then with grammars automatically inferred from the user interface.  We also show how to conduct systematic attacks on these servers, notably with code and SQL injection.\n",
     "\n",
     "* [Testing Graphical User Interfaces](GUIFuzzer.ipynb) explores how to generate tests for Graphical User Interfaces (GUIs), generalizing from rich Web applications to mobile apps, and systematically exploring user interfaces through forms and navigation elements."


### PR DESCRIPTION
An overview of "Part V: Domain-Specific Fuzzing" has missed a description of a chapter "Testing compilers". The patch fixes that.