### PR TITLE
Branch Distances in SearchBasedFuzzer is wrong

### DIFF
--- a/notebooks/SearchBasedFuzzer.ipynb
+++ b/notebooks/SearchBasedFuzzer.ipynb
@@ -1217,9 +1217,9 @@
     "| ------------- |:-------------:| -----:|\n",
     "| a == b      | abs(a - b) | 1 |\n",
     "| a != b      | 1          | abs(a - b) |\n",
-    "| a < b       | b - a + 1  | a - b      |\n",
-    "| a <= b      | b - a      | a - b + 1  |\n",
-    "| a > b       | a - b + 1  | b - a      |\n",
+    "| a < b       | a - b + 1  | b - a      |\n",
+    "| a <= b      | a - b      | b - a + 1  |\n",
+    "| a > b       | b - a + 1  | a - b      |\n",
     "\n",
     "\n",
     "Note that several of the calculations add a constant `1`. The reason for this is quite simple: Suppose we want to have `a < b` evaluate to true, and let `a = 27` and `b = 27`. The condition is not true, but simply taking the difference would give us a result of `0`. To avoid this, we have to add a constant value. It is not important whether this value is `1` -- any positive constant works."


### PR DESCRIPTION
I believe last 3 lines in the table is wrong
```
    "| Condition | Distance True | Distance False |\n",
    "| ------------- |:-------------:| -----:|\n",
    "| a == b      | abs(a - b) | 1 |\n",
    "| a != b      | 1          | abs(a - b) |\n",
    "| a < b       | b - a + 1  | a - b      |\n",
    "| a <= b      | b - a      | a - b + 1  |\n",
    "| a > b       | a - b + 1  | b - a      |\n",
```
for example,
to make `a<b` true, we want estimate the distance betweern unstatisfied condition and statisfied condition.
in unstatisfied condition, a>=b. so, the distance true should be `a - b + 1` instead of `b - a +1`

similarly, the distance false should be `b - a` instead of `a - b`
