### PR TITLE
Fix off-by-one error

### DIFF
--- a/notebooks/Fuzzer.ipynb
+++ b/notebooks/Fuzzer.ipynb
@@ -876,7 +876,7 @@
    "source": [
     "The chance is actually higher than you may think. If you remove `/` (the root of all files), for instance, your entire file system will be gone. If you remove `.` (the current folder), all the files in the current directory will be gone. \n",
     "\n",
-    "The probability of generating a string that is exactly 1 character long is 1/101, this is because the length of the string is determined by calling random.randrange(0, max_length + 1), where the default value of max_length is 100. Per the description given of random.randrange, that should return a random number in [0, 99 + 1). So, we end up with the inclusive range [0, 100] where there are 101 values in the interval.\n",
+    "The probability of generating a string that is exactly 1 character long is 1/101, this is because the length of the string is determined by calling random.randrange(0, max_length + 1), where the default value of max_length is 100. Per the description given of random.randrange, that should return a random number in [0, 100 + 1). So, we end up with the inclusive range [0, 100] where there are 101 values in the interval.\n",
     "\n",
     "For `/` or `.` to be produced, you need a string length of 1 (chance: 1 out of 101) and one of these two characters (chance: 2 out of 32)."
    ]


### PR DESCRIPTION
Fix an off-by-one error regarding the interval sampled by `random.randrange`.