### PR TITLE
Fix: enable re-import .ipynb when error ocurred

### DIFF
--- a/notebooks/shared/bookutils/import_notebooks.py
+++ b/notebooks/shared/bookutils/import_notebooks.py
@@ -121,7 +121,15 @@ class NotebookLoader:
             self.lines[fullname] = '\n'.join(source)
             p = len(self.lines[fullname].split('\n')) + 1
             assert lno == p
-    
+            
+        except ModuleNotFoundError as e:
+            # remove the module from sys.modules to allow re-import
+            del sys.modules[fullname]
+            try:
+                raise e
+            finally:
+                pass
+
         finally:
             self.shell.user_ns = save_user_ns
             data = self.lines[fullname]


### PR DESCRIPTION
Hi, I’m a Korean student taking some classes with Prof. DongSun Kim.

Executing GreyboxFuzzer.ipynb, we found an error when importing generate_maze_code from ControlFlow. First, we got an error that is "ModuleNotFoundError: No module named 'graphviz'". And then we got an another error that is "ImportError: cannot import name 'generate_maze_code' from 'Controlflow' (Controlflow.ipynb)". The second problem has some issues.

At the time, I had solved the problem with just changing the name of module:from 'ControlFlow' to 'Controlflow'. I was confused because I couldn't understand why this solution works.

### Here is how to invoke same error
  1) While importing an .ipynb file, 
  2) the .ipynb file also doing import other module,
  3) An error occured when importing in the sequence of 2)
  4) the .ipynb file can not be imported again.


### fixed code
In python, the same module cannot be imported twice(`unless importlib.reload()` is used). 
If the first import fails, the imported module remains in `sys.modules`, preventing it from being re-imported successfully.
So, I changed some code in `load_module()` in bookutils.import_notebooks.py. It delete module if the error occured.


Problem in .ipynb import code (bookutils.import_notebooks.py)
executing exec() function, load_module() does not control an error that is occured when importing othre files. Other errors are controled as exception by some code(I don't know actual lines) like assert, function not found error, and so on. 

The reason problem was solved with changing capital F to small f.
Using function os.path checks file with case insensitive, but load_module function uses user input (import "Controlflow") string as a key value of sys.modules dict. The string is case sensitive and treat "Controlflow" as new module, and it makes importing success.