### PR TITLE
Fixed a bug in FunctionCoverageRunner

### DIFF
--- a/docs/code/MutationFuzzer.py
+++ b/docs/code/MutationFuzzer.py
@@ -423,12 +423,12 @@ from .Coverage import Coverage, population_coverage, Location
 
 class FunctionCoverageRunner(FunctionRunner):
     def run_function(self, inp: str) -> Any:
-        with Coverage() as cov:
-            try:
+        try:
+            with Coverage() as cov:
                 result = super().run_function(inp)
-            except Exception as exc:
-                self._coverage = cov.coverage()
-                raise exc
+        except Exception as exc:
+            self._coverage = cov.coverage()
+            raise exc
 
         self._coverage = cov.coverage()
         return result


### PR DESCRIPTION
Fixed a bug in FunctionCoverageRunner that caused the Coverage()-object to instrument itself if the intrumented function throws an exception.