### PR TITLE
fix: send_back grouping of send_back() in InformationFlow

### DIFF
--- a/docs/beta/_sources/InformationFlow.ipynb
+++ b/docs/beta/_sources/InformationFlow.ipynb
@@ -5309,7 +5309,7 @@
    "outputs": [],
    "source": [
     "def send_back(s):\n",
-    "    assert not isinstance(s, tstr) and not s.taint == 'SECRET'  # type: ignore\n",
+    "    assert not (isinstance(s, tstr) and s.taint == 'SECRET')  # type: ignore\n",
     "    ..."
    ]
   },
@@ -5337,7 +5337,7 @@
       "    send_back(reply)\n",
       "    ~~~~~~~~~^^^^^^^\n",
       "  File \"/var/folders/n2/xd9445p97rb3xh7m1dfx8_4h0006ts/T/ipykernel_24314/3158733057.py\", line 2, in send_back\n",
-      "    assert not isinstance(s, tstr) and not s.taint == 'SECRET'  # type: ignore\n",
+      "    assert not (isinstance(s, tstr) and s.taint == 'SECRET')  # type: ignore\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "AssertionError (expected)\n"
      ]

--- a/docs/beta/code/InformationFlow.py
+++ b/docs/beta/code/InformationFlow.py
@@ -842,7 +842,7 @@ if __name__ == '__main__':
     reply.taint  # type: ignore
 
 def send_back(s):
-    assert not isinstance(s, tstr) and not s.taint == 'SECRET'  # type: ignore
+    assert not (isinstance(s, tstr) and s.taint == 'SECRET')  # type: ignore
     ...
 
 if __name__ == '__main__':

--- a/docs/beta/html/_sources/InformationFlow.ipynb
+++ b/docs/beta/html/_sources/InformationFlow.ipynb
@@ -4117,7 +4117,7 @@
    "outputs": [],
    "source": [
     "def send_back(s):\n",
-    "    assert not isinstance(s, tstr) and not s.taint == 'SECRET'  # type: ignore\n",
+    "    assert not (isinstance(s, tstr) and s.taint == 'SECRET')  # type: ignore\n",
     "    ..."
    ]
   },
@@ -4144,7 +4144,7 @@
       "  File \"/var/folders/n2/xd9445p97rb3xh7m1dfx8_4h0006ts/T/ipykernel_34365/3747050841.py\", line 2, in <module>\n",
       "    send_back(reply)\n",
       "  File \"/var/folders/n2/xd9445p97rb3xh7m1dfx8_4h0006ts/T/ipykernel_34365/3158733057.py\", line 2, in send_back\n",
-      "    assert not isinstance(s, tstr) and not s.taint == 'SECRET'  # type: ignore\n",
+      "    assert not (isinstance(s, tstr) and s.taint == 'SECRET')  # type: ignore\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "AssertionError (expected)\n"
      ]

--- a/docs/beta/notebooks/InformationFlow.ipynb
+++ b/docs/beta/notebooks/InformationFlow.ipynb
@@ -5309,7 +5309,7 @@
    "outputs": [],
    "source": [
     "def send_back(s):\n",
-    "    assert not isinstance(s, tstr) and not s.taint == 'SECRET'  # type: ignore\n",
+    "    assert not (isinstance(s, tstr) and s.taint == 'SECRET')  # type: ignore\n",
     "    ..."
    ]
   },

--- a/docs/beta/slides/InformationFlow.slides.html
+++ b/docs/beta/slides/InformationFlow.slides.html
@@ -10948,7 +10948,7 @@ AssertionError: Need a string with trusted taint (expected)
     send_back(reply)
     ~~~~~~~~~^^^^^^^
   File "/var/folders/n2/xd9445p97rb3xh7m1dfx8_4h0006ts/T/ipykernel_24314/3158733057.py", line 2, in send_back
-    assert not isinstance(s, tstr) and not s.taint == 'SECRET'  # type: ignore
+    assert not (isinstance(s, tstr) and s.taint == 'SECRET')  # type: ignore
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 AssertionError (expected)
 </pre>

--- a/docs/code/InformationFlow.py
+++ b/docs/code/InformationFlow.py
@@ -896,7 +896,7 @@ if __name__ == '__main__':
     reply.taint  # type: ignore
 
 def send_back(s):
-    assert not isinstance(s, tstr) and not s.taint == 'SECRET'  # type: ignore
+    assert not (isinstance(s, tstr) and s.taint == 'SECRET')  # type: ignore
     ...
 
 if __name__ == '__main__':

--- a/docs/notebooks/InformationFlow.ipynb
+++ b/docs/notebooks/InformationFlow.ipynb
@@ -4117,7 +4117,7 @@
    "outputs": [],
    "source": [
     "def send_back(s):\n",
-    "    assert not isinstance(s, tstr) and not s.taint == 'SECRET'  # type: ignore\n",
+    "    assert not (isinstance(s, tstr) and s.taint == 'SECRET')  # type: ignore\n",
     "    ..."
    ]
   },

--- a/notebooks/InformationFlow.ipynb
+++ b/notebooks/InformationFlow.ipynb
@@ -2064,7 +2064,7 @@
    "outputs": [],
    "source": [
     "def send_back(s):\n",
-    "    assert not isinstance(s, tstr) and not s.taint == 'SECRET'  # type: ignore\n",
+    "    assert not (isinstance(s, tstr) and s.taint == 'SECRET')  # type: ignore\n",
     "    ..."
    ]
   },


### PR DESCRIPTION
I believe the grouping is wrong, as `not s.taint == 'SECRET' ` is unreachable if `not isinstance(s, tstr)`.